### PR TITLE
fix: persist Discord config in ConfigMap

### DIFF
--- a/apps/homelab/openclaw/configmap.yaml
+++ b/apps/homelab/openclaw/configmap.yaml
@@ -33,6 +33,13 @@ data:
         ]
       },
       "cron": { "enabled": false },
+      "plugins": {
+        "entries": {
+          "discord": {
+            "enabled": true
+          }
+        }
+      },
       "channels": {
         "discord": {
           "enabled": true,
@@ -40,6 +47,23 @@ data:
             "source": "env",
             "provider": "default",
             "id": "DISCORD_BOT_TOKEN"
+          },
+          "groupPolicy": "allowlist",
+          "allowFrom": ["134033064593588224"],
+          "dmPolicy": "allowlist",
+          "status": "online",
+          "activity": "your DMs",
+          "activityType": 2,
+          "guilds": {
+            "134033291471749120": {
+              "slug": "vyrtl",
+              "users": ["134033064593588224"],
+              "channels": {
+                "1513892143457112164": {
+                  "enabled": true
+                }
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
**What:** Updates the openclaw ConfigMap with the full Discord configuration and plugins entry.

**Why:** The ConfigMap gets copied into the pod on every restart (via init container), so any local edits to the JSON config get wiped. This bakes the Discord settings into the ConfigMap so they survive restarts.

**Changes:**
- Added `plugins.entries.discord` section
- Added guild ID, channel ID, user allowlist, DM policy, and presence settings to Discord config

Closes the issue where Discord would go offline after pod restarts.