### PR TITLE
feat: add GitHub App credentials to env

### DIFF
--- a/apps/homelab/openclaw/configmap.yaml
+++ b/apps/homelab/openclaw/configmap.yaml
@@ -33,6 +33,13 @@ data:
         ]
       },
       "cron": { "enabled": false },
+      "plugins": {
+        "entries": {
+          "discord": {
+            "enabled": true
+          }
+        }
+      },
       "channels": {
         "discord": {
           "enabled": true,
@@ -40,6 +47,23 @@ data:
             "source": "env",
             "provider": "default",
             "id": "DISCORD_BOT_TOKEN"
+          },
+          "groupPolicy": "allowlist",
+          "allowFrom": ["134033064593588224"],
+          "dmPolicy": "allowlist",
+          "status": "online",
+          "activity": "your DMs",
+          "activityType": 2,
+          "guilds": {
+            "134033291471749120": {
+              "slug": "vyrtl",
+              "users": ["134033064593588224"],
+              "channels": {
+                "1513892143457112164": {
+                  "enabled": true
+                }
+              }
+            }
           }
         }
       }

--- a/apps/homelab/openclaw/helmrelease.yaml
+++ b/apps/homelab/openclaw/helmrelease.yaml
@@ -72,6 +72,16 @@ spec:
                   secretKeyRef:
                     name: openclaw-secret
                     key: GITHUB_TOKEN
+              GITHUB_APP_ID:
+                valueFrom:
+                  secretKeyRef:
+                    name: openclaw-secret
+                    key: GITHUB_APP_ID
+              GITHUB_APP_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: openclaw-secret
+                    key: GITHUB_APP_KEY
             probes:
               liveness:
                 enabled: true


### PR DESCRIPTION
**What:** Exposes  and  from 1Password as env vars.

**Why:** Lets Claw authenticate as its own GitHub App instead of using a shared PAT. Future PRs will show as authored by the bot, so Jon can review, approve, and merge normally.

**Prerequisite:** GitHub App has been created and IDs/keys stored in 1Password  entry.